### PR TITLE
Update _ink.js

### DIFF
--- a/src/js/lib/_ink.js
+++ b/src/js/lib/_ink.js
@@ -349,6 +349,7 @@ module.exports = function (angularApp) {
                 Effect.wrapInput($$(selectors));
 
                 Array.prototype.forEach.call($$(selectors), function(i) {
+                    if (i.className.indexOf('no-ink') !== -1) return;
                     if ('ontouchstart' in window) {
                         i.addEventListener('touchstart', Effect.show, false);
                         i.addEventListener('touchend', Effect.hide, false);


### PR DESCRIPTION
Exclude elements with the class `no-ink` from activating the ink effect. 

So far using `ionicMaterialInk.displayEffect();` or not, are the only choices I am aware of.